### PR TITLE
[CHORE] use correct logger in rate limiting logic

### DIFF
--- a/src/serverInfo.ts
+++ b/src/serverInfo.ts
@@ -31,7 +31,7 @@ const octokit = new ThrottledOktokit({
       );
 
       if (options.request.retryCount <= NUMBER_OF_RETRIES) {
-        console.info(`Retrying after ${retryAfter} seconds`);
+        log.info(`Retrying after ${retryAfter} seconds`);
         return true;
       }
 


### PR DESCRIPTION
So that rate limiting logs are included in the relevant logfire spans.