### PR TITLE
chore: replace mcp-boilerplate submodule with npm package

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "src/shared/boilerplate"]
-	path = src/shared/boilerplate
-	url = git@github.com:timescale/mcp-boilerplate-node

--- a/README.md
+++ b/README.md
@@ -7,21 +7,7 @@ A wrapper around the GitHub API to provide some focused tools to LLMs via the [M
 Cloning and running the server locally.
 
 ```bash
-git clone --recurse-submodules git@github.com:timescale/tiger-gh-mcp-server.git
-```
-
-### Submodules
-
-This project uses git submodules to include the mcp boilerplate code. If you cloned the repo without the `--recurse-submodules` flag, run the following command to initialize and update the submodules:
-
-```bash
-git submodule update --init --recursive
-```
-
-You may also need to run this command if you pull changes that update a submodule. You can simplify this process by changing you git configuration to automatically update submodules when you pull:
-
-```bash
-git config --global submodule.recurse true
+git clone git@github.com:timescale/tiger-gh-mcp-server.git
 ```
 
 ### Building

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@octokit/rest": "^22.0.0",
         "@tigerdata/mcp-boilerplate": "^0.1.8",
         "dotenv": "^17.2.0",
-        "express": "^5.1.0",
         "zod": "^3.23.8"
       },
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,21 +9,9 @@
       "version": "0.1.0",
       "license": "UNLICENSED",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.15.1",
         "@octokit/plugin-throttling": "^11.0.1",
         "@octokit/rest": "^22.0.0",
-        "@opentelemetry/api": "^1.9.0",
-        "@opentelemetry/api-logs": "^0.203.0",
-        "@opentelemetry/auto-instrumentations-node": "^0.62.0",
-        "@opentelemetry/exporter-logs-otlp-http": "^0.203.0",
-        "@opentelemetry/exporter-trace-otlp-grpc": "^0.203.0",
-        "@opentelemetry/instrumentation-http": "^0.203.0",
-        "@opentelemetry/resources": "^2.0.1",
-        "@opentelemetry/sdk-logs": "^0.203.0",
-        "@opentelemetry/sdk-metrics": "^2.0.1",
-        "@opentelemetry/sdk-node": "^0.203.0",
-        "@opentelemetry/sdk-trace-base": "^2.0.1",
-        "@opentelemetry/sdk-trace-node": "^2.0.1",
+        "@tigerdata/mcp-boilerplate": "^0.1.8",
         "dotenv": "^17.2.0",
         "express": "^5.1.0",
         "zod": "^3.23.8"
@@ -32,7 +20,6 @@
         "tiger-gh-mcp-server": "dist/index.js"
       },
       "devDependencies": {
-        "@types/express": "^5.0.3",
         "@types/node": "^22.16.4",
         "ai": "^5.0.17",
         "prettier": "^3.6.2",
@@ -1769,22 +1756,30 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@tigerdata/mcp-boilerplate": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@tigerdata/mcp-boilerplate/-/mcp-boilerplate-0.1.8.tgz",
+      "integrity": "sha512-V8WBZIn+WnAR4HK5oEe0KWODmcibwO6hAeIQcsGir2t118KlbhknElEitDWSqydHUaEsu8biVFC5aKHNVhF9UA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.15.1",
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/auto-instrumentations-node": "^0.62.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "^0.203.0",
+        "@opentelemetry/instrumentation-http": "^0.203.0",
+        "@opentelemetry/sdk-metrics": "^2.0.1",
+        "@opentelemetry/sdk-node": "^0.203.0",
+        "@opentelemetry/sdk-trace-node": "^2.0.1",
+        "express": "^5.1.0",
+        "raw-body": "^3.0.1",
+        "zod": "^3.23.8"
+      }
+    },
     "node_modules/@types/aws-lambda": {
       "version": "8.10.150",
       "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.150.tgz",
       "integrity": "sha512-AX+AbjH/rH5ezX1fbK8onC/a+HyQHo7QGmvoxAE42n22OsciAxvZoZNEr22tbXs8WfP1nIsBjKDpgPm3HjOZbA==",
       "license": "MIT"
-    },
-    "node_modules/@types/body-parser": {
-      "version": "1.19.6",
-      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
-      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/connect": "*",
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/bunyan": {
       "version": "1.8.11",
@@ -1804,38 +1799,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/express": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.3.tgz",
-      "integrity": "sha512-wGA0NX93b19/dZC1J18tKWVIYWyyF2ZjT9vin/NRu0qzzvfVzWjs04iq2rQ3H65vCTQYlRqs3YHfY7zjdV+9Kw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/body-parser": "*",
-        "@types/express-serve-static-core": "^5.0.0",
-        "@types/serve-static": "*"
-      }
-    },
-    "node_modules/@types/express-serve-static-core": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.7.tgz",
-      "integrity": "sha512-R+33OsgWw7rOhD1emjU7dzCDHucJrgJXMA5PYCzJxVil0dsyx5iBEPHqpPfiKNJQb7lZ1vxwoLR4Z87bBUpeGQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "@types/qs": "*",
-        "@types/range-parser": "*",
-        "@types/send": "*"
-      }
-    },
-    "node_modules/@types/http-errors": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
-      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/memcached": {
       "version": "2.2.10",
       "resolved": "https://registry.npmjs.org/@types/memcached/-/memcached-2.2.10.tgz",
@@ -1844,13 +1807,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/mime": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
-      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/mysql": {
       "version": "2.15.27",
@@ -1897,43 +1853,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/pg": "*"
-      }
-    },
-    "node_modules/@types/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/range-parser": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
-      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/send": {
-      "version": "0.17.5",
-      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.5.tgz",
-      "integrity": "sha512-z6F2D3cOStZvuk2SaP6YrwkNO65iTZcwA2ZkSABegdkAh/lf+Aa/YQndZVfmEXT5vgAp6zv06VQ3ejSVjAny4w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/mime": "^1",
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/serve-static": {
-      "version": "1.15.8",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.8.tgz",
-      "integrity": "sha512-roei0UY3LhpOJvjbIP6ZZFngyLKl5dskOtDhxY5THRSpO+ZI+nzJ+m5yUMzGrp89YRa7lvknKkMYjqQFGwA7Sg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/http-errors": "*",
-        "@types/node": "*",
-        "@types/send": "*"
       }
     },
     "node_modules/@types/tedious": {
@@ -3456,18 +3375,34 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
-      "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.1.tgz",
+      "integrity": "sha512-9G8cA+tuMS75+6G/TzW8OtLzmBDMo8p1JRxN5AZ+LAp8uxGA8V8GZm4GQ4/N5QNQEnLmg6SS7wyuSmbKepiKqA==",
       "license": "MIT",
       "dependencies": {
         "bytes": "3.1.2",
         "http-errors": "2.0.0",
-        "iconv-lite": "0.6.3",
+        "iconv-lite": "0.7.0",
         "unpipe": "1.0.0"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
+      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/rechoir": {

--- a/package.json
+++ b/package.json
@@ -21,27 +21,14 @@
     "inspector": "npx @modelcontextprotocol/inspector"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.15.1",
     "@octokit/plugin-throttling": "^11.0.1",
     "@octokit/rest": "^22.0.0",
-    "@opentelemetry/api": "^1.9.0",
-    "@opentelemetry/api-logs": "^0.203.0",
-    "@opentelemetry/auto-instrumentations-node": "^0.62.0",
-    "@opentelemetry/exporter-logs-otlp-http": "^0.203.0",
-    "@opentelemetry/exporter-trace-otlp-grpc": "^0.203.0",
-    "@opentelemetry/instrumentation-http": "^0.203.0",
-    "@opentelemetry/resources": "^2.0.1",
-    "@opentelemetry/sdk-logs": "^0.203.0",
-    "@opentelemetry/sdk-metrics": "^2.0.1",
-    "@opentelemetry/sdk-node": "^0.203.0",
-    "@opentelemetry/sdk-trace-base": "^2.0.1",
-    "@opentelemetry/sdk-trace-node": "^2.0.1",
+    "@tigerdata/mcp-boilerplate": "^0.1.8",
     "dotenv": "^17.2.0",
     "express": "^5.1.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {
-    "@types/express": "^5.0.3",
     "@types/node": "^22.16.4",
     "ai": "^5.0.17",
     "prettier": "^3.6.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "@octokit/rest": "^22.0.0",
     "@tigerdata/mcp-boilerplate": "^0.1.8",
     "dotenv": "^17.2.0",
-    "express": "^5.1.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/src/apis/getPullRequest.ts
+++ b/src/apis/getPullRequest.ts
@@ -1,5 +1,5 @@
+import { ApiFactory } from '@tigerdata/mcp-boilerplate';
 import { z } from 'zod';
-import { ApiFactory } from '../shared/boilerplate/src/types.js';
 import { ServerContext, zPullRequestWithComments } from '../types.js';
 import { parsePullRequestURL } from '../util/parsePullRequestURL.js';
 import { getCommits } from '../util/getCommits.js';

--- a/src/apis/getRecentCommits.ts
+++ b/src/apis/getRecentCommits.ts
@@ -1,5 +1,5 @@
+import { ApiFactory } from '@tigerdata/mcp-boilerplate';
 import { z } from 'zod';
-import { ApiFactory } from '../shared/boilerplate/src/types.js';
 import { ServerContext } from '../types.js';
 
 const inputSchema = {

--- a/src/apis/getRecentPRsInvolvingUser.ts
+++ b/src/apis/getRecentPRsInvolvingUser.ts
@@ -1,5 +1,5 @@
+import { ApiFactory } from '@tigerdata/mcp-boilerplate';
 import { z } from 'zod';
-import { ApiFactory } from '../shared/boilerplate/src/types.js';
 import { ServerContext, zPullRequest } from '../types.js';
 
 const inputSchema = {

--- a/src/apis/getUsers.ts
+++ b/src/apis/getUsers.ts
@@ -1,6 +1,6 @@
+import { ApiFactory } from '@tigerdata/mcp-boilerplate';
 import { z } from 'zod';
 import { ServerContext, zUser } from '../types.js';
-import { ApiFactory } from '../shared/boilerplate/src/types.js';
 
 const inputSchema = {} as const;
 

--- a/src/httpServer.ts
+++ b/src/httpServer.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
+import { httpServerFactory } from '@tigerdata/mcp-boilerplate';
 import { apiFactories } from './apis/index.js';
-import { httpServerFactory } from './shared/boilerplate/src/httpServer.js';
 import { context, serverInfo } from './serverInfo.js';
 
 export const { registerCleanupFn } = httpServerFactory({

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import 'dotenv/config';
-import { cliEntrypoint } from './shared/boilerplate/src/cliEntrypoint.js';
+import { cliEntrypoint } from '@tigerdata/mcp-boilerplate';
 
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';

--- a/src/serverInfo.ts
+++ b/src/serverInfo.ts
@@ -1,7 +1,7 @@
-import { Octokit } from '@octokit/rest';
-import { ServerContext, User } from './types.js';
 import { throttling } from '@octokit/plugin-throttling';
-import { log } from './shared/boilerplate/src/logger.js';
+import { Octokit } from '@octokit/rest';
+import { log } from '@tigerdata/mcp-boilerplate';
+import { ServerContext, User } from './types.js';
 import { Store } from './util/store.js';
 import { getUsers } from './util/getUsers.js';
 

--- a/src/stdio.ts
+++ b/src/stdio.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
+import { stdioServerFactory } from '@tigerdata/mcp-boilerplate';
 import { apiFactories } from './apis/index.js';
 import { context, serverInfo } from './serverInfo.js';
-import { stdioServerFactory } from './shared/boilerplate/src/stdio.js';
 
 stdioServerFactory({
   ...serverInfo,

--- a/src/util/getUsers.ts
+++ b/src/util/getUsers.ts
@@ -1,6 +1,6 @@
 import { Octokit } from '@octokit/rest';
+import { log } from '@tigerdata/mcp-boilerplate';
 import { User } from '../types.js';
-import { log } from '../shared/boilerplate/src/logger.js';
 
 const getUsers = async (octokit: Octokit, org: string): Promise<User[]> => {
   log.info('Fetching members within organization', { org });


### PR DESCRIPTION
PR replaces the usage of the git submodule with npm package for `@tigerdata/mcp-boilerplate`.